### PR TITLE
samples projects refer to sdk source on git

### DIFF
--- a/examples/BingAdsExamples/BingAdsConsoleApp/BingAdsConsoleApp.csproj
+++ b/examples/BingAdsExamples/BingAdsConsoleApp/BingAdsConsoleApp.csproj
@@ -33,6 +33,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.BingAds">
+      <HintPath>..\..\..\BingAdsApiSDK\bin\Debug\Microsoft.BingAds.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />

--- a/examples/BingAdsExamples/BingAdsExamplesLibrary/BingAdsExamplesLibrary.csproj
+++ b/examples/BingAdsExamples/BingAdsExamplesLibrary/BingAdsExamplesLibrary.csproj
@@ -30,6 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.BingAds">
+      <HintPath>..\..\..\BingAdsApiSDK\bin\Debug\Microsoft.BingAds.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />

--- a/examples/BingAdsExamples/BingAdsWpfApp/BingAdsWpfApp.csproj
+++ b/examples/BingAdsExamples/BingAdsWpfApp/BingAdsWpfApp.csproj
@@ -35,6 +35,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.BingAds">
+      <HintPath>..\..\..\BingAdsApiSDK\bin\Debug\Microsoft.BingAds.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Data" />


### PR DESCRIPTION
By default the samples will refer to the GitHub build. This assumes a client would build the SDK first, and then build/run the examples. Given the samples are cloned together with the SDK source this seems like a logical default. Of course package management can be changed e.g. use NuGet.