### PR TITLE
add example for use of In parameter in Account Search

### DIFF
--- a/examples/BingAdsExamples/BingAdsExamplesLibrary/v12/SearchUserAccounts.cs
+++ b/examples/BingAdsExamples/BingAdsExamplesLibrary/v12/SearchUserAccounts.cs
@@ -88,5 +88,75 @@ namespace BingAdsExamplesLibrary.V12
                 OutputStatusMessage(ex.Message);
             }
         }
+
+        /// <summary>
+        /// This example demonstrates how to use the In predicate to search for a range of account numbers
+        /// </summary>
+        /// <param name="authorizationData">
+        /// The authorization data for the request
+        /// </param>
+        /// <param name="accountNumbers">
+        /// The account numbers to search for
+        /// </param>
+        /// <returns></returns>
+        public async Task SearchAccountsByNumber(AuthorizationData authorizationData, IEnumerable<string> accountNumbers)
+        {
+            try
+            {
+                CustomerManagementExampleHelper CustomerManagementExampleHelper = new CustomerManagementExampleHelper(this.OutputStatusMessage);
+                CustomerManagementExampleHelper.CustomerManagementService = new ServiceClient<ICustomerManagementService>(authorizationData);
+                
+                // Search for the Bing Ads accounts associated with the passed in account numbers
+
+                var predicate = new Predicate
+                {
+                    Field = "AccountNumber",
+                    Operator = PredicateOperator.In,
+                    Value = string.Join(";", accountNumbers)
+                };
+
+                var paging = new Paging
+                {
+                    Index = 0,
+                    Size = 10
+                };
+
+                var accounts = (await CustomerManagementExampleHelper.SearchAccountsAsync(
+                    new[] { predicate },
+                    null,
+                    paging
+                    ))?.Accounts.ToArray();
+
+                OutputStatusMessage("The following Bing Ads accounts were found: \n");
+                foreach (var account in accounts)
+                {
+                    CustomerManagementExampleHelper.OutputAdvertiserAccount(account);
+
+                    // You can find out which pilot features the customer is able to use. 
+                    // Each account could belong to a different customer, so use the customer ID in each account.
+                    var featurePilotFlags = (await CustomerManagementExampleHelper.GetCustomerPilotFeaturesAsync(account.ParentCustomerId)).FeaturePilotFlags;
+                    OutputStatusMessage("Customer Pilot flags:");
+                    OutputStatusMessage(string.Join("; ", featurePilotFlags.Select(flag => string.Format("{0}", flag))));
+                }
+            }
+            // Catch authentication exceptions
+            catch (OAuthTokenRequestException ex)
+            {
+                OutputStatusMessage(string.Format("Couldn't get OAuth tokens. Error: {0}. Description: {1}", ex.Details.Error, ex.Details.Description));
+            }
+            // Catch Customer Management service exceptions
+            catch (FaultException<Microsoft.BingAds.V12.CustomerManagement.AdApiFaultDetail> ex)
+            {
+                OutputStatusMessage(string.Join("; ", ex.Detail.Errors.Select(error => string.Format("{0}: {1}", error.Code, error.Message))));
+            }
+            catch (FaultException<Microsoft.BingAds.V12.CustomerManagement.ApiFault> ex)
+            {
+                OutputStatusMessage(string.Join("; ", ex.Detail.OperationErrors.Select(error => string.Format("{0}: {1}", error.Code, error.Message))));
+            }
+            catch (Exception ex)
+            {
+                OutputStatusMessage(ex.Message);
+            }
+        }
     }
 }


### PR DESCRIPTION
This fixes #64 which I opened by including an example for the use of the In predicate.