### PR TITLE
column combination restrictions

### DIFF
--- a/examples/BingAdsExamples/BingAdsExamplesLibrary/v12/ReportRequests.cs
+++ b/examples/BingAdsExamples/BingAdsExamplesLibrary/v12/ReportRequests.cs
@@ -520,7 +520,6 @@ namespace BingAdsExamplesLibrary.V12
                     AccountPerformanceReportColumn.Impressions,
                     AccountPerformanceReportColumn.Ctr,
                     AccountPerformanceReportColumn.AverageCpc,
-                    AccountPerformanceReportColumn.ImpressionSharePercent,
                     AccountPerformanceReportColumn.Spend,
                 },
             };

--- a/examples/BingAdsExamples/BingAdsExamplesLibrary/v13/ReportRequests.cs
+++ b/examples/BingAdsExamples/BingAdsExamplesLibrary/v13/ReportRequests.cs
@@ -511,7 +511,6 @@ namespace BingAdsExamplesLibrary.V13
                     AccountPerformanceReportColumn.Impressions,
                     AccountPerformanceReportColumn.Ctr,
                     AccountPerformanceReportColumn.AverageCpc,
-                    AccountPerformanceReportColumn.ImpressionSharePercent,
                     AccountPerformanceReportColumn.Spend,
                 },
             };


### PR DESCRIPTION
ImpressionSharePercent cannot be included if BidMatchType, DeviceType, or TopVsOther are present.
https://docs.microsoft.com/en-us/advertising/guides/reports?view=bingads-13#columnrestrictions