### PR TITLE
proactively fetch new access token, if expired

### DIFF
--- a/BingAdsApiSDK/Internal/OAuthWithAuthorizationCode.cs
+++ b/BingAdsApiSDK/Internal/OAuthWithAuthorizationCode.cs
@@ -67,6 +67,8 @@ namespace Microsoft.BingAds.Internal
     /// </summary>
     public abstract class OAuthWithAuthorizationCode : OAuthAuthorization
     {
+        private const int AccessTokenExpiryBufferInSec = 60;
+
         private readonly string _optionalClientSecret;
 
         private readonly Uri _redirectionUri;
@@ -93,6 +95,11 @@ namespace Microsoft.BingAds.Internal
         /// Occurs when a new refresh token is received.
         /// </summary>
         public event EventHandler<NewOAuthTokensReceivedEventArgs> NewOAuthTokensReceived;
+
+        /// <summary>
+        /// Information about when does AccessToken expire. 
+        /// </summary>
+        protected internal DateTime ExpiresOn { get; protected set; } = DateTime.UtcNow;
 
         /// <summary>
         /// Initializes a new instance of the OAuthWithAuthorizationCode class.
@@ -304,6 +311,8 @@ namespace Microsoft.BingAds.Internal
                 GrantParamName = "code",
                 GrantValue = code,
             }, RequireLiveConnect).ConfigureAwait(false);
+
+            ExpiresOn = DateTime.UtcNow.AddSeconds(OAuthTokens.AccessTokenExpiresInSeconds - AccessTokenExpiryBufferInSec);
 
             RaiseNewTokensReceivedEvent();
 

--- a/BingAdsApiSDK/Internal/OAuthWithAuthorizationCode.cs
+++ b/BingAdsApiSDK/Internal/OAuthWithAuthorizationCode.cs
@@ -67,7 +67,7 @@ namespace Microsoft.BingAds.Internal
     /// </summary>
     public abstract class OAuthWithAuthorizationCode : OAuthAuthorization
     {
-        private const int AccessTokenExpiryBufferInSec = 60;
+        private const int AccessTokenExpiryBufferInSec = 30;
 
         private readonly string _optionalClientSecret;
 

--- a/BingAdsApiSDK/Internal/OAuthWithAuthorizationCode.cs
+++ b/BingAdsApiSDK/Internal/OAuthWithAuthorizationCode.cs
@@ -67,8 +67,6 @@ namespace Microsoft.BingAds.Internal
     /// </summary>
     public abstract class OAuthWithAuthorizationCode : OAuthAuthorization
     {
-        private const int AccessTokenExpiryBufferInSec = 30;
-
         private readonly string _optionalClientSecret;
 
         private readonly Uri _redirectionUri;
@@ -312,7 +310,7 @@ namespace Microsoft.BingAds.Internal
                 GrantValue = code,
             }, RequireLiveConnect).ConfigureAwait(false);
 
-            ExpiresOn = DateTime.UtcNow.AddSeconds(OAuthTokens.AccessTokenExpiresInSeconds - AccessTokenExpiryBufferInSec);
+            ExpiresOn = DateTime.UtcNow.AddSeconds(OAuthTokens.AccessTokenExpiresInSeconds);
 
             RaiseNewTokensReceivedEvent();
 

--- a/BingAdsApiSDK/Internal/OAuthWithAuthorizationCode.cs
+++ b/BingAdsApiSDK/Internal/OAuthWithAuthorizationCode.cs
@@ -95,11 +95,6 @@ namespace Microsoft.BingAds.Internal
         public event EventHandler<NewOAuthTokensReceivedEventArgs> NewOAuthTokensReceived;
 
         /// <summary>
-        /// Information about when does AccessToken expire. 
-        /// </summary>
-        protected internal DateTime ExpiresOn { get; protected set; } = DateTime.UtcNow;
-
-        /// <summary>
         /// Initializes a new instance of the OAuthWithAuthorizationCode class.
         /// </summary>
         /// <param name="clientId">
@@ -309,8 +304,6 @@ namespace Microsoft.BingAds.Internal
                 GrantParamName = "code",
                 GrantValue = code,
             }, RequireLiveConnect).ConfigureAwait(false);
-
-            ExpiresOn = DateTime.UtcNow.AddSeconds(OAuthTokens.AccessTokenExpiresInSeconds);
 
             RaiseNewTokensReceivedEvent();
 

--- a/BingAdsApiSDK/OAuthTokens.cs
+++ b/BingAdsApiSDK/OAuthTokens.cs
@@ -47,6 +47,7 @@
 //  fitness for a particular purpose and non-infringement.
 //=====================================================================================================================================================
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.BingAds
@@ -77,6 +78,7 @@ namespace Microsoft.BingAds
             _accessTokenExpiresInSeconds = accessTokenExpiresInSeconds;
             _refreshToken = refreshToken;
             _responseFragments = fragments;
+            AccessTokenExpiresOn = DateTime.UtcNow.AddSeconds(accessTokenExpiresInSeconds);
         }
 
         /// <summary>
@@ -88,6 +90,11 @@ namespace Microsoft.BingAds
         /// Expiration time for the corresponding access token in seconds.
         /// </summary>
         public int AccessTokenExpiresInSeconds => _accessTokenExpiresInSeconds;
+
+        /// <summary>
+        /// Expiration absolute time for the corresponding access token in seconds.
+        /// </summary>
+        public DateTime AccessTokenExpiresOn { get; private set; }
 
         /// <summary>
         /// OAuth refresh token that can be user to refresh an access token. 

--- a/BingAdsApiSDK/ServiceClient.cs
+++ b/BingAdsApiSDK/ServiceClient.cs
@@ -194,7 +194,7 @@ namespace Microsoft.BingAds
 
             var client = _serviceClientFactory.CreateServiceFromFactory(_channelFactory);
 
-            var needToRefreshToken = false;
+            var needToRefreshToken = RefreshOAuthTokensAutomatically && DateTime.UtcNow > AccessTokenExpiresOn;
 
             do
             {
@@ -366,6 +366,9 @@ namespace Microsoft.BingAds
                 field.SetValue(request, Convert.ChangeType(authorizationDataValue, targetType));
             }
         }
+
+        private DateTime AccessTokenExpiresOn 
+            => (_authorizationData.Authentication as OAuthWithAuthorizationCode)?.ExpiresOn ?? DateTime.MaxValue;
 
         private async Task RefreshAccessToken()
         {

--- a/BingAdsApiSDK/ServiceClient.cs
+++ b/BingAdsApiSDK/ServiceClient.cs
@@ -75,8 +75,6 @@ namespace Microsoft.BingAds
     public class ServiceClient<TService> : IDisposable
         where TService : class
     {
-        private readonly object syncRoot = new object();
-
         private readonly IServiceClientFactory _serviceClientFactory;
 
         private IChannelFactory<TService> _channelFactory;

--- a/BingAdsApiSDK/ServiceClient.cs
+++ b/BingAdsApiSDK/ServiceClient.cs
@@ -200,19 +200,11 @@ namespace Microsoft.BingAds
 
             do
             {
-                if (needToRefreshToken) // double lock pattern to ensure multiple threads tries to refresh token exactly once
+                if (needToRefreshToken)
                 {
-                    lock (syncRoot)
-                    {
-                        if (needToRefreshToken)
-                        {
-                            RefreshAccessToken().Wait();
+                    await RefreshAccessToken().ConfigureAwait(false);
 
-                            _authorizationData.Authentication.SetAuthenticationFieldsOnApiRequestObject(request);
-
-                            needToRefreshToken = false;
-                        }
-                    }
+                    _authorizationData.Authentication.SetAuthenticationFieldsOnApiRequestObject(request);
                 }
 
                 try

--- a/BingAdsApiSDK/ServiceClient.cs
+++ b/BingAdsApiSDK/ServiceClient.cs
@@ -368,7 +368,7 @@ namespace Microsoft.BingAds
         }
 
         private DateTime AccessTokenExpiresOn 
-            => (_authorizationData.Authentication as OAuthWithAuthorizationCode)?.ExpiresOn ?? DateTime.MaxValue;
+            => (_authorizationData.Authentication as OAuthWithAuthorizationCode)?.OAuthTokens?.AccessTokenExpiresOn ?? DateTime.MaxValue;
 
         private async Task RefreshAccessToken()
         {


### PR DESCRIPTION
#83 

PR calculates the value of needToRefreshToken proactively, and tries to prevent calling BingAdsApi with expired AccessToken.