### PR TITLE
13.0.15.2

### DIFF
--- a/BingAdsApiSDK/Microsoft.BingAds.csproj
+++ b/BingAdsApiSDK/Microsoft.BingAds.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>13.0.15.1</Version>
+    <Version>13.0.15.2</Version>
     <QInstrumentForCoverage>false</QInstrumentForCoverage> 
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='AnyCPU'">
@@ -9,10 +9,10 @@
     <NoWarn>1591,1574</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Http" Version="4.5.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+    <PackageReference Include="System.ServiceModel.Http" Version="4.7.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 	<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 </Project>

--- a/BingAdsApiSDK/V13/Internal/Bulk/StringExtensions.cs
+++ b/BingAdsApiSDK/V13/Internal/Bulk/StringExtensions.cs
@@ -278,10 +278,16 @@ namespace Microsoft.BingAds.V13.Internal.Bulk
 
         public static string ToAdGroupFrequencyCapSettingsString(this IList<FrequencyCapSettings> frequencyCapSettings)
         {
-            if (frequencyCapSettings == null || !frequencyCapSettings.Any())
+            if (frequencyCapSettings == null)
             {
                 return null;
             }
+
+            if (!frequencyCapSettings.Any())
+            {
+                return DeleteValue;
+            }
+
             string s = JsonConvert.SerializeObject(frequencyCapSettings, new StringEnumConverter());
             return s;
         }
@@ -292,6 +298,12 @@ namespace Microsoft.BingAds.V13.Internal.Bulk
             {
                 return null;
             }
+
+            if (s.Equals(DeleteValue))
+            {
+                return new List<FrequencyCapSettings>();
+            }
+
             var r = JsonConvert.DeserializeObject<IList<FrequencyCapSettings>>(s);
             return r;
         }


### PR DESCRIPTION
- Update dependencies versions: System.ServiceModel.Primitives and System.ServiceModel.Http to 4.7.0; System.Configuration.ConfigurationManager to 5.0.0; Microsoft.Extensions.Logging to 6.0.0.
- Fix bug that can not reset AdGroup FrequencyCapSettings via bulk upload.