### PR TITLE
update System.ServiceModel.Http version to 4.10.2

### DIFF
--- a/BingAdsApiSDK/Microsoft.BingAds.csproj
+++ b/BingAdsApiSDK/Microsoft.BingAds.csproj
@@ -9,7 +9,7 @@
     <NoWarn>1591,1574</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Http" Version="4.7.0" PrivateAssets="All" />
+    <PackageReference Include="System.ServiceModel.Http" Version="4.10.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />


### PR DESCRIPTION
this is because System.ServiceModel.Http(4.7.0) depends on System.Private.ServiceModel(4.7.0), which depends on System.Security.Cryptography.Xml(4.5.0). this version of System.Security.Cryptography.Xml has at least a vulnerability issue.