### PR TITLE
Improve BulkEntityReader null reference error handling

### DIFF
--- a/BingAdsApiSDK/V13/Bulk/BulkEntityReader.cs
+++ b/BingAdsApiSDK/V13/Bulk/BulkEntityReader.cs
@@ -118,6 +118,13 @@ namespace Microsoft.BingAds.V13.Bulk
         /// </remarks>
         private IEnumerable<BulkEntity> ReadNextBatch()
         {
+            // We only expect _bulkRecordReader to be null if this has been disposed, which currently
+            // happens when the wrapping Enumerator is disposed.
+            if(_bulkRecordReader == null)
+            {
+                throw new ObjectDisposedException("Results can only be enumerated once.")
+            }
+
             // Parse the next row in the source. The returned object can be:
             // * Object inherited from SingleLineBulkEntity - representing an entity from a single line, such as BulkCampaign or BulkKeyword or BulkSiteLink
             // * Object interited from BulkEntityIdentifier with Status = Deleted - representing a delete all row


### PR DESCRIPTION
Proposed fixes for #127.

This would simply make it so that it is more clear that this result from the BulkService's `DownloadEntitiesAsync` is unable to be enumerated more than once.